### PR TITLE
Feat/Board 조회수 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
 
     implementation("org.springframework.boot:spring-boot-starter-data-redis") // Redis 의존성 추가
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 kotlin {

--- a/src/main/kotlin/edu/example/dev_3_5_cc/Dev35CcApplication.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/Dev35CcApplication.kt
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling // 스케줄링 기능 활성화
 class Dev35CcApplication
 inline val <reified T> T.log : Logger
     get() = LogManager.getLogger()

--- a/src/main/kotlin/edu/example/dev_3_5_cc/api_controller/BoardController.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/api_controller/BoardController.kt
@@ -28,6 +28,7 @@ class BoardController(
     // Board 단일 조회 - 확인 완료
     @GetMapping("/{boardId}")
     fun getBoard(@PathVariable("boardId") boardId : Long) : ResponseEntity<BoardResponseDTO> {
+        boardService.incrementViewCount(boardId)
         return ResponseEntity.ok(boardService.readBoard(boardId))
     }
 

--- a/src/main/kotlin/edu/example/dev_3_5_cc/config/RedisConfig.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/config/RedisConfig.kt
@@ -1,12 +1,21 @@
 package edu.example.dev_3_5_cc.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.GenericToStringSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
 import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
 
 @Configuration
 @EnableCaching  // 캐싱 기능 활성화
@@ -20,13 +29,20 @@ class RedisConfig(
         return LettuceConnectionFactory(host, port)
     }
 
-    // Redis 서버와의 데이터를 주고 받기 위한 RedisTemplate 생성
     @Bean
     fun redisTemplate(): RedisTemplate<String, Any> {
-        val template = RedisTemplate<String, Any>()
-        template.connectionFactory = redisConnectionFactory()
-        template.keySerializer = StringRedisSerializer()
-        template.valueSerializer = StringRedisSerializer()
-        return template
+        val redisTemplate = RedisTemplate<String, Any>()
+
+        redisTemplate.connectionFactory = redisConnectionFactory()
+
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = StringRedisSerializer()
+        redisTemplate.hashKeySerializer = StringRedisSerializer()
+        redisTemplate.hashValueSerializer = StringRedisSerializer()
+
+        redisTemplate.afterPropertiesSet()
+
+        return redisTemplate
     }
+
 }

--- a/src/main/kotlin/edu/example/dev_3_5_cc/config/RedisConfig.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/config/RedisConfig.kt
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
 @EnableCaching  // 캐싱 기능 활성화
@@ -24,6 +25,8 @@ class RedisConfig(
     fun redisTemplate(): RedisTemplate<String, Any> {
         val template = RedisTemplate<String, Any>()
         template.connectionFactory = redisConnectionFactory()
+        template.keySerializer = StringRedisSerializer()
+        template.valueSerializer = StringRedisSerializer()
         return template
     }
 }

--- a/src/main/kotlin/edu/example/dev_3_5_cc/dto/board/BoardListDTO.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/dto/board/BoardListDTO.kt
@@ -12,14 +12,16 @@ data class BoardListDTO (
      val title: String? = null,
      val category: Category? = Category.GENERAL,
      val memberId: String? = null,
-     val createdAt: LocalDateTime? = null
+     val createdAt: LocalDateTime? = null,
+     val viewCount: Int? = null,
 ): Serializable {
     constructor(board: Board) : this(
         boardId = board.boardId,
         title = board.title,
         category = board.category,
         memberId = board.member?.memberId,
-        createdAt = board.createdAt
+        createdAt = board.createdAt,
+        viewCount = board.viewCount
     )
 
 }

--- a/src/main/kotlin/edu/example/dev_3_5_cc/dto/board/BoardResponseDTO.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/dto/board/BoardResponseDTO.kt
@@ -16,7 +16,8 @@ data class BoardResponseDTO (
      var imageFilenames: List<String?>? = null, // 이미지 파일 이름들을 담을 리스트 추가
      var createdAt: LocalDateTime? = null,
      var updatedAt: LocalDateTime?= null,
-     var replies: MutableList<ReplyResponseDTO>? = null
+     var replies: MutableList<ReplyResponseDTO>? = null,
+     var viewCount: Int? = null
 ): Serializable {
     constructor(board: Board) :
             this(
@@ -29,6 +30,7 @@ data class BoardResponseDTO (
                 imageFilenames = board.images.map { it.filename }, // Map images to filenames
                 createdAt = board.createdAt,
                 updatedAt = board.updatedAt,
-                replies = board.replies?.mapNotNull { it?.let{ReplyResponseDTO(it)} }?.toMutableList()
+                replies = board.replies?.mapNotNull { it?.let{ReplyResponseDTO(it)} }?.toMutableList(),
+                viewCount = board.viewCount
             )
 }

--- a/src/main/kotlin/edu/example/dev_3_5_cc/entity/Board.kt
+++ b/src/main/kotlin/edu/example/dev_3_5_cc/entity/Board.kt
@@ -39,7 +39,9 @@ data class Board(
     var createdAt: LocalDateTime? = null,
 
     @LastModifiedDate
-    var updatedAt: LocalDateTime? = null
+    var updatedAt: LocalDateTime? = null,
+
+    var viewCount: Int? = 0
 
 ){
     // 이미지 추가


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
게시판 조회 수 기능 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->

 - 사용자의 IP주소를 기준으로 조회수를 올리고 24시간 이후 다시 조회수를 올릴 수 있게 설정했습니다.
 
 - Redis 캐시 서버에 board:$boardId:viewed_by:$viewerId 형식으로 중복 방지용 키를 남김
 
 - read요청시 IP주소를 확인하고 캐시서버에 해당하는 중복 방지용 키를 확인
 
 - 키가 존재한다면 조회수 증가 처리X, 키기 없다면 조회수를 올리고 키 삭제
 
 - 증가한 조회수는 캐시서버에 저장
 
 - 스프링부트 서버가 실행중인 동안 10초(임시) 간격으로 DB에 업데이트
 
* 현재는 조회수가 업데이트 되도 캐시를 갱신하는 기능을 구현하지 못해 TalendAPI나 뷰에서는 바로 확인이 안됨

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
